### PR TITLE
69 task refactor from commonjs to es6 modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tc3005b-501-backend",
   "version": "1.0.0",
+  "type": "module",
   "description": "API y Base de Datos para la conexión y el funcionamiento del portal del sistema gestor de viajes",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In this pull request I refactored node.js from commonJS to ES6 modules for the following reasons:
Below is a list of reasons you can include in your GitHub issue description to advocate for switching from CommonJS to ES6 modules:

- **Standardized Language Feature:**  
  ES6 modules are part of the ECMAScript specification, ensuring a consistent, cross-platform module system that is natively supported in modern JavaScript runtimes.

- **Static Analysis and Tree Shaking:**  
  The static structure of ES6 modules enables tools and bundlers to perform effective tree shaking, eliminating dead code and reducing bundle sizes.

- **Cleaner, Modern Syntax:**  
  ES6 introduces a concise and declarative syntax (`import`/`export`) that enhances code readability, maintainability, and reduces boilerplate compared to CommonJS’s `require()` and `module.exports`.

- **Better Tooling Support:**  
  Modern tools like Babel, Webpack, Rollup, and ESLint are optimized for ES6 modules, providing better linting, debugging, and optimization features.

- **Enhanced Asynchronous Importing:**  
  The dynamic `import()` function in ES6 modules returns a promise, which aligns with modern async/await patterns and improves handling of code-splitting and on-demand loading.

- **Future-Proofing the Codebase:**  
  Migrating to ES6 modules positions the project to take advantage of future ECMAScript features and optimizations, ensuring long-term maintainability and compatibility as the language evolves.

- **Scoped Module Behavior:**  
  ES6 modules are strictly scoped to the module, reducing the likelihood of unintended side effects and global namespace pollution.

For more information about the refactor, you can find more about this [here](https://electerious.medium.com/from-commonjs-to-es-modules-how-to-modernize-your-node-js-app-ad8cdd4fb662)