### PR TITLE
chore: close issue 101 create-dummy-data-for-table-deparment

### DIFF
--- a/database/Schema/Dummy.sql
+++ b/database/Schema/Dummy.sql
@@ -50,3 +50,15 @@ INSERT INTO City (city_name) VALUES
     ('Reino de Simba'),
     ('Pisos Picados'),
     ('Bombardino Cocodrilo');
+
+INSERT INTO Department (department_name, costs_center, active) VALUES
+('Finanzas', 'CC001', TRUE),
+('Recursos Humanos', 'CC002', TRUE),
+('IT', 'CC003', TRUE),
+('Marketing', 'CC004', TRUE),
+('Operaciones', 'CC005', TRUE),
+('Servicios Generales', 'CC006', TRUE),
+('Administración ', 'CC007', TRUE),  
+('Sistemas Avanzadosna', 'CC008', FALSE), 
+('Desarrollo y Calidad', 'CC009', TRUE),  
+('Recursos No Humanos', 'CC010', TRUE);  


### PR DESCRIPTION
This update adds dummy data to the Department table, including both conventional and unconventional entries. The 5 conventional entries follow standard department naming conventions and cost center formats, while the 5 unconventional entries include longer names, mixed terms, and one inactive department. This variety of data will help test department handling in different scenarios, ensuring the table can handle both common and edge cases.

