### PR TITLE
feat(db): created RequestWithRouteDetails view

### DIFF
--- a/database/Schema/Views.sql
+++ b/database/Schema/Views.sql
@@ -25,4 +25,46 @@ CREATE OR REPLACE VIEW UserRequestHistory AS
         `Request`.user_id,
         `Request`.last_mod_date,
         Request_status.status;
-        
+
+CREATE OR REPLACE VIEW RequestWithRouteDetails AS
+    SELECT
+        `Request`.request_id,
+        `Request`.user_id,
+        `Request`.request_status_id,
+        `Request`.notes,
+        `Request`.requested_fee,
+        `Request`.imposed_fee,
+        `Request`.request_days,
+        `Request`.creation_date,
+        `Request`.last_mod_date,
+        `Request`.active,
+        GROUP_CONCAT(DISTINCT Country_origin.country_name ORDER BY Route.router_index SEPARATOR ', ') AS origin_countries,
+        GROUP_CONCAT(DISTINCT City_origin.city_name ORDER BY Route.router_index SEPARATOR ', ') AS origin_cities,
+        GROUP_CONCAT(DISTINCT Country_destination.country_name ORDER BY Route.router_index SEPARATOR ', ') AS destination_countries,
+        GROUP_CONCAT(DISTINCT City_destination.city_name ORDER BY Route.router_index SEPARATOR ', ') AS destination_cities
+    FROM
+        `Request`
+        LEFT JOIN Route_Request
+            ON `Request`.request_id = Route_Request.request_id
+        LEFT JOIN Route
+            ON Route_Request.route_id = Route.route_id
+        LEFT JOIN Country AS Country_origin
+            ON Route.id_origin_country = Country_origin.country_id
+        LEFT JOIN City AS City_origin
+            ON Route.id_origin_city = City_origin.city_id
+        LEFT JOIN Country AS Country_destination
+            ON Route.id_destination_country = Country_destination.country_id
+        LEFT JOIN City AS City_destination
+            ON Route.id_destination_city = City_destination.city_id
+    GROUP BY
+        `Request`.request_id,
+        `Request`.user_id,
+        `Request`.request_status_id,
+        `Request`.notes,
+        `Request`.requested_fee,
+        `Request`.imposed_fee,
+        `Request`.request_days,
+        `Request`.creation_date,
+        `Request`.last_mod_date,
+        `Request`.active;
+


### PR DESCRIPTION
## Description

A new view named `UserRequestHistory` has been created, which includes all columns from the `Request` table along with associated route details for each request. Specifically, the view includes the following columns:

- Origin country and city (`origin country`, `origin city`)
- Destination country and city (`destination country`, `destination city`)
- Request status (`status`)
- Grouped countries of origin and destination, ordered by the route index using `GROUP_CONCAT`.

This allows for querying all relevant information about a travel request and its associated routes in a single view.
