### PR TITLE
Update .gitignore for MacOS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ dist
 
 # configuration
 *.cnf
+
+#MacOS Stuff
+.DS_Store


### PR DESCRIPTION
# Chore PR

## Before Submitting

- [x] This is a required activity that does not directly relate to any User Stories.
- [x] PR is linked to a standalone `chore` Task Issue: _Specify the issue here_.
- [x] PR is from a feature branch from `development`.
- [x] PR is being made to the `development` branch.
- [x] Use **only** `git` conventional commits of type `style`, `docs`, `refactor`, or `chore`.

## Description

adds two lines to .gitignore for .DS_Store MacOS files

## Dependent Issues

N/A

## Affected Issues

N/A, but pulling is recommended for MacOS users.
