### PR TITLE
feat(db): add other fields to the view

### DIFF
--- a/database/Schema/Views.sql
+++ b/database/Schema/Views.sql
@@ -26,6 +26,9 @@ CREATE OR REPLACE VIEW UserRequestHistory AS
         `Request`.last_mod_date,
         Request_status.status;
 
+
+
+
 CREATE OR REPLACE VIEW RequestWithRouteDetails AS
     SELECT
         `Request`.request_id,
@@ -38,12 +41,35 @@ CREATE OR REPLACE VIEW RequestWithRouteDetails AS
         `Request`.creation_date,
         `Request`.last_mod_date,
         `Request`.active,
+
+        `User`.user_name,
+        `User`.email AS user_email,
+        `User`.phone_number AS user_phone_number,
+
+        Request_status.status,
+
+        Department.department_name,
+        Department.department_id,
+
         GROUP_CONCAT(DISTINCT Country_origin.country_name ORDER BY Route.router_index SEPARATOR ', ') AS origin_countries,
         GROUP_CONCAT(DISTINCT City_origin.city_name ORDER BY Route.router_index SEPARATOR ', ') AS origin_cities,
         GROUP_CONCAT(DISTINCT Country_destination.country_name ORDER BY Route.router_index SEPARATOR ', ') AS destination_countries,
-        GROUP_CONCAT(DISTINCT City_destination.city_name ORDER BY Route.router_index SEPARATOR ', ') AS destination_cities
+        GROUP_CONCAT(DISTINCT City_destination.city_name ORDER BY Route.router_index SEPARATOR ', ') AS destination_cities,
+        GROUP_CONCAT(DISTINCT Route.beginning_date ORDER BY Route.router_index SEPARATOR ', ') AS beginning_dates,
+        GROUP_CONCAT(DISTINCT Route.beginning_time ORDER BY Route.router_index SEPARATOR ', ') AS beginning_times,
+        GROUP_CONCAT(DISTINCT Route.ending_date ORDER BY Route.router_index SEPARATOR ', ') AS ending_dates,
+        GROUP_CONCAT(DISTINCT Route.ending_time ORDER BY Route.router_index SEPARATOR ', ') AS ending_times,
+        GROUP_CONCAT(DISTINCT Route.hotel_needed ORDER BY Route.router_index SEPARATOR ', ') AS hotel_needed_list,
+        GROUP_CONCAT(DISTINCT Route.plane_needed ORDER BY Route.router_index SEPARATOR ', ') AS plane_needed_list
+
     FROM
         `Request`
+        LEFT JOIN `User`
+            ON `Request`.user_id = `User`.user_id
+        LEFT JOIN `Request_status`
+            ON `Request`.request_status_id = `Request_status`.request_status_id
+        LEFT JOIN `Department`
+            ON `User`.department_id = `Department`.department_id
         LEFT JOIN Route_Request
             ON `Request`.request_id = Route_Request.request_id
         LEFT JOIN Route
@@ -66,5 +92,10 @@ CREATE OR REPLACE VIEW RequestWithRouteDetails AS
         `Request`.request_days,
         `Request`.creation_date,
         `Request`.last_mod_date,
-        `Request`.active;
-
+        `Request`.active,
+        `User`.user_name,
+        `User`.email,
+        `User`.phone_number,
+        Request_status.status,
+        Department.department_name,
+        Department.department_id;


### PR DESCRIPTION
This PR enhances the existing RequestWithRouteDetails SQL view by adding several new fields to support broader reporting and feature needs. It now includes user details (user_name, user_email, user_phone_number), request status (status), department information (department_name, department_id), and additional route attributes (beginning_date, beginning_time, ending_date, ending_time, hotel_needed, plane_needed) aggregated using GROUP_CONCAT. The original fields and structure of the view remain unchanged to ensure full backward compatibility. These additions will support improved data access for downstream features such as reporting, filtering, and enhanced request summaries.








