### PR TITLE
fix: add request_days on model for get-user-request endpoint

### DIFF
--- a/models/applicantModel.js
+++ b/models/applicantModel.js
@@ -523,6 +523,7 @@ const Applicant = {
         r.notes,
         r.requested_fee,
         r.imposed_fee,
+        r.request_days,
         r.creation_date,
         r.last_mod_date,
         u.user_name,


### PR DESCRIPTION
# Feature PR

## Before Submitting

- [x] PR is linked to an issue: #248 
- [x] PR is from feature branch created from the `development` branch.
- [ ] PR is to the `development` branch.
- [x] `git` conventional commits.

## Description

This PR adds support for returning the `request_days` field in the full travel request response via the `/get-user-request/{request_id}` endpoint. The field is now properly included in the SQL query and passed through to the controller output.

This ensures that clients receive the total number of days of the travel request directly, without needing to recalculate it from route data.

## Dependent issues

None

## Affected Issues

None
