### PR TITLE
feat: changed get-travel-requests and get-travel-request to userContr…

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,5 +1,5 @@
 import * as userService from '../services/userService.js';
-
+import User from '../models/userModel.js';
 /**
  * Get user data by ID
  * @param {Object} req - Express request object
@@ -30,3 +30,80 @@ export async function getUserData(req, res) {
     return res.status(500).json({ error: 'Internal server error' });
   }
 }
+
+export const getTravelRequestsByDeptStatus = async (req, res) => {
+  const { dept, status, n } = req.params;
+
+  try {
+    const travelRequests = await User.getTravelRequestsByDeptStatus(dept, status, n);
+
+    if (!travelRequests || travelRequests.length === 0) {
+      return res.status(404).json({ error: "No travel requests found" });
+    }
+
+    const formatted = travelRequests.map((req) => ({
+      request_id: req.request_id,
+      user_id: req.user_id,
+      destination_country: req.destination_country,
+      beginning_date: formatDate(req.beginning_date),
+      ending_date: formatDate(req.ending_date),
+      request_status: req.request_status,
+    }));
+
+    return res.status(200).json(formatted);
+  } catch (err) {
+    console.error("Error in getTravelRequestsByDeptStatus controller:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+export const getTravelRequestById = async (req, res) => {
+  const { request_id } = req.params;
+
+  try {
+    const requestData = await User.getTravelRequestById(request_id);
+
+    if (!requestData || requestData.length === 0) {
+      return res.status(404).json({ error: "Travel request not found" });
+    }
+
+    const base = requestData[0];
+
+    const response = {
+      request_id: base.request_id,
+      request_status: base.request_status,
+      notes: base.notes,
+      requested_fee: base.requested_fee,
+      imposed_fee: base.imposed_fee,
+      request_days: base.request_days,
+      creation_date: formatDate(base.creation_date),
+      user: {
+        user_name: base.user_name,
+        user_email: base.user_email,
+        user_phone_number: base.user_phone_number
+      },
+      routes: requestData.map((row) => ({
+        router_index: row.router_index,
+        origin_country: row.origin_country,
+        origin_city: row.origin_city,
+        destination_country: row.destination_country,
+        destination_city: row.destination_city,
+        beginning_date: formatDate(row.beginning_date),
+        beginning_time: row.beginning_time,
+        ending_date: formatDate(row.ending_date),
+        ending_time: row.ending_time,
+        hotel_needed: row.hotel_needed,
+        plane_needed: row.plane_needed
+      }))
+    };
+
+    return res.status(200).json(response);
+  } catch (err) {
+    console.error("Error in getTravelRequestById controller:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+const formatDate = (date) => {
+  return new Date(date).toISOString().split('T')[0];
+};

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -1,35 +1,120 @@
-import db from '../database/config/db.js';
+import pool from '../database/config/db.js';
 
-/**
- * Get all user data by ID
- * @param {number} userId - User ID
- * @returns {Promise<Object>} - User data
- */
-export async function getUserData(userId) {
-  const connection = await db.getConnection();
+const User = {
+  // Get all user data by ID
+  async getUserData(userId) {
+    let conn;
+    try {
+      conn = await pool.getConnection();
+      const rows = await conn.query(
+        `SELECT 
+          u.user_id, 
+          u.user_name, 
+          u.email, 
+          u.phone_number,
+          u.workstation,
+          d.department_name,
+          d.costs_center,
+          u.creation_date, 
+          r.role_name
+        FROM User u
+        JOIN Role r ON u.role_id = r.role_id
+        JOIN Department d ON u.department_id = d.department_id
+        WHERE u.user_id = ?`,
+        [userId]
+      );
+
+      return rows[0];
+    } finally {
+      if (conn) conn.release();
+    }
+  },
+
+  async getTravelRequestById(request_id) {
+    let conn;
+    const query = `
+      SELECT 
+        r.request_id,
+        rs.status AS request_status,
+        r.notes,
+        r.requested_fee,
+        r.imposed_fee,
+        r.request_days,
+        r.creation_date,
+        u.user_name,
+        u.email AS user_email,
+        u.phone_number AS user_phone_number,
+
+        ro.router_index,
+        co1.country_name AS origin_country,
+        ci1.city_name AS origin_city,
+        co2.country_name AS destination_country,
+        ci2.city_name AS destination_city,
+
+        ro.beginning_date,
+        ro.beginning_time,
+        ro.ending_date,
+        ro.ending_time,
+        ro.hotel_needed,
+        ro.plane_needed
+
+      FROM Request r
+      JOIN User u ON r.user_id = u.user_id
+      JOIN Request_status rs ON r.request_status_id = rs.request_status_id
+      LEFT JOIN Route_Request rr ON r.request_id = rr.request_id
+      LEFT JOIN Route ro ON rr.route_id = ro.route_id
+      LEFT JOIN Country co1 ON ro.id_origin_country = co1.country_id
+      LEFT JOIN City ci1 ON ro.id_origin_city = ci1.city_id
+      LEFT JOIN Country co2 ON ro.id_destination_country = co2.country_id
+      LEFT JOIN City ci2 ON ro.id_destination_city = ci2.city_id
+      WHERE r.request_id = ?
+      ORDER BY ro.router_index ASC
+    `;
+
+    try {
+      conn = await pool.getConnection();
+      const rows = await conn.query(query, [request_id]);
+      return rows;
+    } catch (error) {
+      console.error('Error in getTravelRequestById:', error);
+      throw error;
+    } finally {
+      if (conn) conn.release();
+    }
+  },
+
+  async getTravelRequestsByDeptStatus(dept, statusId, n) {
+  const conn = await pool.getConnection();
   try {
-    const rows = await connection.query(
-      `SELECT 
-        u.user_id, 
-        u.user_name, 
-        u.email, 
-        u.phone_number,
-        u.workstation,
-        d.department_name,
-        d.costs_center,
-        u.creation_date, 
-        r.role_name
-      FROM User u
-      JOIN Role r ON u.role_id = r.role_id
-      JOIN Department d ON u.department_id = d.department_id
-      WHERE u.user_id = ?`,
-      [userId]
-    );
+    const baseQuery = `
+      SELECT
+        r.request_id,
+        u.user_id,
+        c.country_name AS destination_country,
+        ro.beginning_date,
+        ro.ending_date,
+        rs.status AS request_status
+      FROM Request r
+      JOIN User u ON r.user_id = u.user_id
+      JOIN Request_status rs ON r.request_status_id = rs.request_status_id
+      JOIN Route_Request rr ON r.request_id = rr.request_id
+      JOIN Route ro ON rr.route_id = ro.route_id
+      JOIN Country c ON ro.id_destination_country = c.country_id
+      WHERE u.department_id = ?
+        AND r.request_status_id = ?
+      GROUP BY r.request_id
+      ORDER BY r.creation_date DESC
+      ${n ? 'LIMIT ?' : ''}
+    `;
 
-    
-    return rows[0];
-
+    const params = n ? [dept, statusId, Number(n)] : [dept, statusId];
+    const rows = await conn.query(baseQuery, params);
+    return rows;
   } finally {
-    connection.release();
+    conn.release();
   }
-}
+},
+
+};
+
+export default User;

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -4,5 +4,10 @@ import * as userController from '../controllers/userController.js';
 
 router.get('/get-user-data/:user_id', userController.getUserData);
 
+router.route('/get-travel-request/:request_id')
+    .get(userController.getTravelRequestById);
+
+router.route('/get-travel-requests/:dept/:status/:n?')
+    .get(userController.getTravelRequestsByDeptStatus);
 
 export default router;


### PR DESCRIPTION
# Feature PR

## Before Submitting

- [x] PR is linked to an issue: #262 
- [x] PR is from feature branch created from the `development` branch.
- [x] PR is to the `development` branch.
- [x] `git` conventional commits.

## Description

This feature adds the `get-travel-request/{request_id}` and `get-travel-requests/{dept}/{status}/{n}` endpoints to the `UserController`:

- `get-travel-request/{request_id}` retrieves full travel request details by ID, including user and route info.
- `get-travel-requests/{dept}/{status}/{n}` retrieves filtered requests by department and status ID, with optional limit.

Status filtering now uses `request_status_id` (integer) instead of the status name, and responses follow the OpenAPI YAML structure.

## Dependent issues

- Allows future expansion of filters for department-level dashboards.
- Enables integration with the travel validation workflow.

## Affected Issues

- Replaces and unifies travel request logic previously handled in `ApplicantController`.
