### PR TITLE
Changed first Request_status to 'Aberto' to 'Borrador' in Prepopulate.sql

### DIFF
--- a/database/Schema/Prepopulate.sql
+++ b/database/Schema/Prepopulate.sql
@@ -18,7 +18,7 @@ INSERT INTO AlertMessage (message_text) VALUES
     ('Los comprobantes están listos para validación.');
 
 INSERT INTO Request_status (status) VALUES
-    ('Abierto'),
+    ('Borrador'),
     ('Primera Revisión'),
     ('Segunda Revisión'),
     ('Cotización del Viaje'),


### PR DESCRIPTION
# Chore PR

## Before Submitting

- [x] This is a required activity that does not directly relate to any User Stories.
- [x] PR is linked to a standalone `chore` Task Issue: #291 
- [x] PR is from a feature branch from `development`.
- [x] PR is being made to the `development` branch.
- [ ] Use **only** `git` conventional commits of type `style`, `docs`, `refactor`, or `chore`.

## Description

Looking for a more self explaining name to the first Request_status inserted in Prepopulated.sql, wich is dedicaded when a Request has been created and saved but not sent to an authorizer (Draft = 'Borrador').

## Dependent Issues

NA

## Affected Issues

NA
