### PR TITLE
271 sub task create a trigger to update the wallet

### DIFF
--- a/database/Schema/Triggers.sql
+++ b/database/Schema/Triggers.sql
@@ -35,4 +35,29 @@ BEGIN
     END IF;
 END$$
 
+-- Trigger to deduct from wallet when a fee is imposed
+CREATE OR REPLACE TRIGGER DeductFromWalletOnFeeImposed
+AFTER UPDATE ON Request
+FOR EACH ROW
+BEGIN
+    IF NEW.imposed_fee IS NOT NULL AND (OLD.imposed_fee IS NULL OR NEW.imposed_fee != OLD.imposed_fee) THEN
+        UPDATE `User`
+        SET wallet = wallet - NEW.imposed_fee
+        WHERE user_id = NEW.user_id;
+    END IF;
+END$$
+
+-- Trigger to add to wallet when a receipt is approved
+CREATE OR REPLACE TRIGGER AddToWalletOnReceiptApproved
+AFTER UPDATE ON Receipt
+FOR EACH ROW
+BEGIN
+    IF NEW.validation = 'Aprobado' AND OLD.validation != 'Aprobado' THEN
+        UPDATE `User` u
+        JOIN Request r ON r.request_id = NEW.request_id
+        SET u.wallet = u.wallet + r.imposed_fee
+        WHERE u.user_id = r.user_id;
+    END IF;
+END$$
+
 DELIMITER ;

--- a/database/Schema/Triggers.sql
+++ b/database/Schema/Triggers.sql
@@ -35,19 +35,17 @@ BEGIN
     END IF;
 END$$
 
--- Trigger to deduct from wallet when a fee is imposed
-CREATE OR REPLACE TRIGGER DeductFromWalletOnFeeImposed
+CREATE TRIGGER DeductFromWalletOnFeeImposed
 AFTER UPDATE ON Request
 FOR EACH ROW
 BEGIN
     IF NEW.imposed_fee IS NOT NULL AND (OLD.imposed_fee IS NULL OR NEW.imposed_fee != OLD.imposed_fee) THEN
         UPDATE `User`
-        SET wallet = wallet - NEW.imposed_fee
+        SET wallet = wallet - (NEW.imposed_fee - IFNULL(OLD.imposed_fee, 0))
         WHERE user_id = NEW.user_id;
     END IF;
 END$$
 
--- Trigger to add to wallet when a receipt is approved
 CREATE OR REPLACE TRIGGER AddToWalletOnReceiptApproved
 AFTER UPDATE ON Receipt
 FOR EACH ROW
@@ -55,7 +53,7 @@ BEGIN
     IF NEW.validation = 'Aprobado' AND OLD.validation != 'Aprobado' THEN
         UPDATE `User` u
         JOIN Request r ON r.request_id = NEW.request_id
-        SET u.wallet = u.wallet + r.imposed_fee
+        SET u.wallet = u.wallet + NEW.amount
         WHERE u.user_id = r.user_id;
     END IF;
 END$$


### PR DESCRIPTION

# Feature PR


- [x] PR is linked to an issue: https://github.com/101-Coconsulting/TC3005B.501-Backend/issues/271
- [x] `git` conventional commits.

## Description

This PR introduces two database triggers to automate wallet balance updates:

- **Trigger 1**: Deducts `imposed_fee` from the user's wallet when the fee is set or updated on a `Request`.
- **Trigger 2**: Credits the user's wallet when a `Receipt` related to their request is marked as `Aprobado`.

These triggers ensure consistent, automatic financial adjustments based on user actions and request/receipt lifecycle updates.

## Dependent issues

- Enables downstream logic that relies on accurate wallet tracking
- Supports future reporting and automation involving user balances

## Affected Issues
https://github.com/101-Coconsulting/TC3005B.501-Backend/issues/271

